### PR TITLE
Project Woo - New features for WC integration

### DIFF
--- a/woocommerce-yotpo/lib/yotpo-api/Yotpo.php
+++ b/woocommerce-yotpo/lib/yotpo-api/Yotpo.php
@@ -32,8 +32,14 @@ class Yotpo {
                 break;
             case 'POST':
             	curl_setopt($this->request, CURLOPT_POSTFIELDS, $vars);
-            	curl_setopt($this->request, CURLOPT_HTTPHEADER, array('Content-Type: application/json', 'Content-length: '.strlen($vars)));            	
+            	curl_setopt($this->request, CURLOPT_HTTPHEADER, array('Content-Type: application/json', 'Content-length: '.strlen($vars)));
                 curl_setopt($this->request, CURLOPT_POST, true);
+                break;
+
+            case 'PUT': //There was no 'PUT' originally.
+           	 	curl_setopt($this->request, CURLOPT_CUSTOMREQUEST, 'PUT');
+           	 	curl_setopt($this->request, CURLOPT_HTTPHEADER, array('Content-Type: application/json', 'Content-length: '.strlen($vars)));
+            	curl_setopt($this->request, CURLOPT_POSTFIELDS, $vars);
                 break;
             default:
                 curl_setopt($this->request, CURLOPT_CUSTOMREQUEST, $method);
@@ -59,7 +65,7 @@ class Yotpo {
         $this->error = '';
         $this->request = curl_init();
         if (is_array($vars)) {
-        	if($method == 'POST') {
+        	if($method == 'POST' || $method == 'PUT') {
         		$vars = json_encode($vars);
         	}
         	else {
@@ -358,6 +364,27 @@ class Yotpo {
         return $array;
     }
 
+
+	public function create_mass_products(array $products_hash) {
+	$request = self::build_request(
+	                array(
+	            'utoken' => 'utoken',
+	            'products' => 'products'
+	                ), $products_hash);
+	$app_key = $this->get_app_key($products_hash);
+	return $this->post("/apps/$app_key/products/mass_create", $request);
+	}
+
+
+	public function update_mass_products(array $products_hash) { //I've added a definition to PUT calls.
+	$request = self::build_request(
+	                array(
+	            'utoken' => 'utoken',
+	            'products' => 'products'
+	                ), $products_hash);
+	$app_key = $this->get_app_key($products_hash);
+	return $this->put("/apps/$app_key/products/mass_update", $request);
+	}
 }
 
 ?>

--- a/woocommerce-yotpo/templates/wc-yotpo-settings.php
+++ b/woocommerce-yotpo/templates/wc-yotpo-settings.php
@@ -23,7 +23,24 @@ function wc_display_yotpo_admin_page() {
         } elseif (isset($_POST['yotpo_past_orders'])) {
             wc_yotpo_send_past_orders();
             wc_display_yotpo_settings();
-        } else {
+        } elseif (isset($_POST['yotpo_export_catalog'])) {
+            $is_successful = wc_yotpo_product_catalog_export('all');
+            $is_successful ? wc_yotpo_display_message("Done. Please note that this process might take up to 24 hours.") : wc_yotpo_display_message("Error in sending catalog.", true);
+            wc_display_yotpo_settings();
+        } elseif (isset($_POST['yotpo_export_catalog_csv'])) {
+            wc_yotpo_product_catalog_csv();
+            die();
+            wc_display_yotpo_settings();
+        } elseif (isset($_POST['yotpo_export_catalog_create'])) {
+            $is_successful = wc_yotpo_product_catalog_export('create');
+            $is_successful ? wc_yotpo_display_message("Creation Mode, Done. Please note that this process might take up to 24 hours.") : wc_yotpo_display_message("Error in catalog creation mode.", true);
+            wc_display_yotpo_settings();
+        } elseif (isset($_POST['yotpo_export_catalog_update'])) {
+            $is_successful = wc_yotpo_product_catalog_export('update');
+            $is_successful ? wc_yotpo_display_message("Update Mode, Done. Please note that this process might take up to 24 hours.") : wc_yotpo_display_message("Error in catalog creation mode.", true);
+            wc_display_yotpo_settings();
+        }
+        else {
             $yotpo_settings = get_option('yotpo_settings', wc_yotpo_get_degault_settings());
             if (empty($yotpo_settings['app_key']) && empty($yotpo_settings['secret'])) {
                 wc_display_yotpo_register();
@@ -125,6 +142,11 @@ function wc_display_yotpo_settings($success_type = false) {
 		   		       <td><input type='checkbox' name='yotpo_bottom_line_enabled_category' value='1' " . checked(1, $yotpo_settings['bottom_line_enabled_category'], false) . " />		   		       
 		   		       </td>
 		   		     </tr>
+                    <tr valign='top'>
+                       <th scope='row'><div>Pull product variants:</div></th>
+                       <td><input type='checkbox' name='yotpo_product_variants' value='1' " . checked(1, $yotpo_settings['product_variants'], false) . " />                    
+                       </td>
+                     </tr>
                                      </tr>					  	 
 					 <tr valign='top'>
 		   		       <th scope='row'><div>Order Status:</div></th>
@@ -141,12 +163,31 @@ function wc_display_yotpo_settings($success_type = false) {
 		   		       </td>
 		   		     </tr>
 		           </fieldset>
-		         </table></br>			  		
-		         <div class='buttons-container'>
+		         </table></br>		
+
+            <div class='buttons-container'>
+                 <input type='submit' name='yotpo_export_catalog' value='Export Product Catalog (API)' class='button-secondary' " . disabled(true, empty($app_key) || empty($secret), false) . ">
+ 
+                 <input type='submit' name='yotpo_export_catalog_csv' value='Export Product Catalog (CSV)' class='button-secondary' " . disabled(true, empty($app_key) || empty($secret), false) . ">
+                 </br></br>
+             </div>
+ 
+             <div class='buttons-container'>
+                 <input type='submit' name='yotpo_export_catalog_create' value='Create New Products (API)' class='button-secondary' " . disabled(true, empty($app_key) || empty($secret), false) . ">
+ 
+                 <input type='submit' name='yotpo_export_catalog_update' value='Update Existing Products (API)' class='button-secondary' " . disabled(true, empty($app_key) || empty($secret), false) . ">
+             
+                 </br></br>
+             </div>
+
+		    <div class='buttons-container'>
 		        <button type='button' id='yotpo-export-reviews' class='button-secondary' " . disabled(true, empty($app_key) || empty($secret), false) . ">Export Reviews</button>
+
 				<input type='submit' name='yotpo_settings' value='Update' class='button-primary' id='save_yotpo_settings'/>$submit_past_orders_button
-			  </br></br><p class='description'>*Learn <a href='http://support.yotpo.com/entries/24454261-Exporting-reviews-for-Woocommerce' target='_blank'>how to export your existing reviews</a> into Yotpo.</p>
+
+			    </br></br> <p class='description'>*Learn <a href='http://support.yotpo.com/entries/24454261-Exporting-reviews-for-Woocommerce' target='_blank'>how to export your existing reviews</a> into Yotpo.</p>
 			</div>
+
 		  </form>
 		  <iframe name='yotpo_export_reviews_frame' style='display: none;'></iframe>
 		  <form action='' method='get' target='yotpo_export_reviews_frame' style='display: none;'>
@@ -167,6 +208,7 @@ function wc_proccess_yotpo_settings() {
         'widget_tab_name' => $_POST['yotpo_widget_tab_name'],
         'bottom_line_enabled_product' => isset($_POST['yotpo_bottom_line_enabled_product']) ? true : false,
         'bottom_line_enabled_category' => isset($_POST['yotpo_bottom_line_enabled_category']) ? true : false,
+        'product_variants' => isset($_POST['yotpo_product_variants']) ? true : false,
         'yotpo_order_status' => $_POST['yotpo_order_status'],
         'yotpo_language_as_site' => isset($_POST['yotpo_language_as_site']) ? true : false,
         'disable_native_review_system' => isset($_POST['disable_native_review_system']) ? true : false,

--- a/woocommerce-yotpo/wc_yotpo.php
+++ b/woocommerce-yotpo/wc_yotpo.php
@@ -544,7 +544,7 @@ function wc_yotpo_product_catalog_export($mode) {
     return $is_successful;
 }
 
-function wc_yotpo_get_catalog_api(){ //NOTE TO SELF: NEED TO ADD "if product is published to site"
+function wc_yotpo_get_catalog_api(){
 	$yotpo_settings = get_option('yotpo_settings', wc_yotpo_get_degault_settings()); //Get yotpo_settings
 	$current_catalog = $yotpo_settings['product_catalog']; //Get the catalog that already exists on our end
 	$variants_status = $yotpo_settings['product_variants']; //Get if the varinats is enabled or disabled

--- a/woocommerce-yotpo/wc_yotpo.php
+++ b/woocommerce-yotpo/wc_yotpo.php
@@ -628,7 +628,7 @@ function wc_yotpo_catalog_mode($arr, $mode, $yotpo_api = null, $app_key = null, 
 						return $response;
 					}
 					else if($mode == "update"){
-						$response ;//= $yotpo_api->update_mass_products($arr);
+						$response = $yotpo_api->update_mass_products($arr);
 						wc_yotpo_log("\r\n\r\n".gmdate('r', time())."\r\nAPI Call: ".$mode."_mass_products\r\nAPI Response: ".$response['code']."\r\nProducts Sent: ".implode(", ",array_keys($arr['products'])));
 						return $response;
 					}


### PR DESCRIPTION
1. Product variants support.
Whole new logic for products (orders, catalog, on-site widgets, etc.) that have variants.

2. Export the store's product catalog to a CSV file in Yotpo's layout.
Currently, customers are not able to export their store's catalog, which caused a lot of frustration among our customers in case they'd like to upload new products, update existing products within their Yotpo account's catalog or migrate to WC from other platforms.

3. Create new products within the Yotpo account's catalog via API using 'create_mass_products' endpoint.
Products that are created using this feature are being saved within 'yotpo_settings' table in the store's DB and will not go through the creation path again.

4. Update products that were created using the creation feature via API using 'update_mass_products' endpoint.

All features were developed following a demand that I've seen in support cases.
Further details can be found here - https://kb.yotpo.com/en/article/project-woo