### PR TITLE
fix undefined array keys in category_page_renders function

### DIFF
--- a/trunk/lib/utils/widgets-rendering-logic.php
+++ b/trunk/lib/utils/widgets-rendering-logic.php
@@ -54,22 +54,23 @@ function v3_render_bottom_line_widgets($v3_widgets_enables) {
 
 // CATEGORY PAGE RENDER
 function category_page_renders($settings): void {
-	$v3_widgets_enables = $settings['v3_widgets_enables'];
-	$v2_widgets_enables = $settings['v2_widgets_enables'];
-	if ($v3_widgets_enables['reviews_carousel_category']) {
-		add_action('woocommerce_after_shop_loop', 'wc_yotpo_show_reviews_carousel_widget', 10);
-	}
-	if ($v3_widgets_enables['promoted_products_category']) {
-		add_action('woocommerce_after_shop_loop', 'wc_yotpo_show_promoted_products_widget', 11);
-	}
-	if ($v3_widgets_enables['reviews_tab_category']) {
-		add_action('wp_footer', 'wc_yotpo_show_reviews_tab_widget', 12);
-	}
-	if (!use_v3_widgets() && $v2_widgets_enables['bottom_line_category']
-		|| (use_v3_widgets() && $v3_widgets_enables['star_rating_category'])
-	) {
-			add_action('woocommerce_after_shop_loop_item', 'wc_yotpo_show_buttomline', 7);
-	}
+    $v3_widgets_enables = isset($settings['v3_widgets_enables']) ? $settings['v3_widgets_enables'] : [];
+    $v2_widgets_enables = isset($settings['v2_widgets_enables']) ? $settings['v2_widgets_enables'] : [];
+
+    if (!empty($v3_widgets_enables['reviews_carousel_category'])) {
+        add_action('woocommerce_after_shop_loop', 'wc_yotpo_show_reviews_carousel_widget', 10);
+    }
+    if (!empty($v3_widgets_enables['promoted_products_category'])) {
+        add_action('woocommerce_after_shop_loop', 'wc_yotpo_show_promoted_products_widget', 11);
+    }
+    if (!empty($v3_widgets_enables['reviews_tab_category'])) {
+        add_action('wp_footer', 'wc_yotpo_show_reviews_tab_widget', 12);
+    }
+    if ((!use_v3_widgets() && !empty($v2_widgets_enables['bottom_line_category'])) ||
+        (use_v3_widgets() && !empty($v3_widgets_enables['star_rating_category']))
+    ) {
+        add_action('woocommerce_after_shop_loop_item', 'wc_yotpo_show_buttomline', 7);
+    }
 }
 
 // REST OF PAGES RENDER


### PR DESCRIPTION
### Problem
The function `category_page_renders` was throwing an error: `Undefined array key "v3_widgets_enables"` and `Undefined array key "v2_widgets_enables"`. This issue occurred when the `$settings` array did not include these keys, leading to unexpected behavior or crashes.

### Solution
- Added checks using `isset()` to ensure the keys `v3_widgets_enables` and `v2_widgets_enables` exist before attempting to access them.
- Applied `!empty()` to verify that the values are not null or empty before performing actions.
- This prevents the function from attempting to access non-existent array keys, ensuring smoother execution without errors.

### Testing
- Manually tested with different `$settings` configurations to ensure the function behaves as expected and no longer throws the error.

### Impact
This fix ensures that the `category_page_renders` function handles cases where the `$settings` array might not contain the expected keys, improving overall stability.
